### PR TITLE
add Falco alert schema

### DIFF
--- a/Findings/Security Finding/Falco/Readme.md
+++ b/Findings/Security Finding/Falco/Readme.md
@@ -1,0 +1,25 @@
+# Event Dossier: Falco
+### Falco Alert
+- **Description**: Translates a Falco alert to OCSF. 
+- **Event References**:
+  - https://falco.org/docs/alerts/channels/#json-output
+
+### OCSF Version: 0.33.0
+ - `activity_id`: `1` (`Generate`)
+ - `category_uid`: `2` `(Findings)`
+ - `class_uid`: `2001` `(Security Finding)`
+ - `metadata.product.name`: `Falco`
+ - `metadata.product.vendor_name`: `Falcosecurity`
+
+### Mapping:
+ - This does not reflect any transformations or evaluations of the data. Some data evaluation and transformation will be necessary for a correct representation in OCSF that matches all requirements.
+
+| OCSF                   | Raw        |
+| ---------------------- | ---------- |
+| `finding.created_time` | `time`     |
+| `finding.desc`         | `output`   |
+| `finding.title`        | `rule`     |
+| `finding.types`        | `source`   |
+| `finding.uid`          | `uuid`     |
+| `metadata.labels`      | `tags`     |
+| `status`               | `priority` |

--- a/Findings/Security Finding/Falco/falco.event
+++ b/Findings/Security Finding/Falco/falco.event
@@ -1,0 +1,21 @@
+{
+    "uuid": "ec834826-90c1-458a-8eec-a014e7266754",
+    "output": "Linux Kernel Module injection using insmod detected (user=%user.name user_loginuid=%user.loginuid parent_process=%proc.pname module=%proc.args %container.info image=%container.image.repository:%container.image.tag)",
+    "priority": "Warning",
+    "rule": "Linux Kernel Module Injection Detected",
+    "time": "2023-01-03T15:11:39.558068644Z",
+    "output_fields": {
+        "container.image.repository": "container.image.repository",
+        "container.image.tag": "container.image.tag",
+        "container.info": "container.info",
+        "proc.args": "proc.args",
+        "proc.pname": "proc.pname",
+        "user.loginuid": "user.loginuid",
+        "user.name": "user.name"
+    },
+    "source": "syscalls",
+    "tags": [
+        "process"
+    ],
+    "hostname": "host0.local"
+}

--- a/Findings/Security Finding/Falco/falco.json
+++ b/Findings/Security Finding/Falco/falco.json
@@ -1,0 +1,87 @@
+{
+    "activity_id": 1,
+    "activity_name": "Generate",
+    "category_name": "Findings",
+    "category_uid": 2,
+    "classname": "Security Finding",
+    "class_uid": 2001,
+    "finding": {
+        "created_time": 1672758699558,
+        "desc": "Linux Kernel Module injection using insmod detected (user=%user.name user_loginuid=%user.loginuid parent_process=%proc.pname module=%proc.args %container.info image=%container.image.repository:%container.image.tag)",
+        "title": "Linux Kernel Module Injection Detected",
+        "types": [
+            "syscalls"
+        ],
+        "uid": "ec834826-90c1-458a-8eec-a014e7266754"
+    },
+    "message": "Linux Kernel Module Injection Detected",
+    "metadata": {
+        "version": "0.1.0",
+        "product": {
+            "vendor_name": "Falcosecurity",
+            "name": "Falco"
+        },
+        "labels": [
+            "process"
+        ]
+    },
+    "observables": [
+        {
+            "name": "hostname",
+            "type": "Other",
+            "type_id": 0,
+            "value": "host0.local"
+        },
+        {
+            "name": "proc.pname",
+            "type": "Other",
+            "type_id": 0,
+            "value": "proc.pname"
+        },
+        {
+            "name": "container.info",
+            "type": "Other",
+            "type_id": 0,
+            "value": "container.info"
+        },
+        {
+            "name": "proc.args",
+            "type": "Other",
+            "type_id": 0,
+            "value": "proc.args"
+        },
+        {
+            "name": "user.loginuid",
+            "type": "Other",
+            "type_id": 0,
+            "value": "user.loginuid"
+        },
+        {
+            "name": "user.name",
+            "type": "Other",
+            "type_id": 0,
+            "value": "user.name"
+        },
+        {
+            "name": "container.image.repository",
+            "type": "Other",
+            "type_id": 0,
+            "value": "container.image.repository"
+        },
+        {
+            "name": "container.image.tag",
+            "type": "Other",
+            "type_id": 0,
+            "value": "container.image.tag"
+        }
+    ],
+    "raw_data": "{\"uuid\":\"ec834826-90c1-458a-8eec-a014e7266754\",\"output\":\"Linux Kernel Module injection using insmod detected (user=%user.name user_loginuid=%user.loginuid parent_process=%proc.pname module=%proc.args %container.info image=%container.image.repository:%container.image.tag)\",\"priority\":\"Warning\",\"rule\":\"Linux Kernel Module Injection Detected\",\"time\":\"2023-01-03T15:11:39.558068644Z\",\"output_fields\":{\"akey\":\"AValue\",\"bkey\":\"BValue\",\"ckey\":\"CValue\",\"container.image.repository\":\"container.image.repository\",\"container.image.tag\":\"container.image.tag\",\"container.info\":\"container.info\",\"dkey\":\"bar\",\"proc.args\":\"proc.args\",\"proc.pname\":\"proc.pname\",\"user.loginuid\":\"user.loginuid\",\"user.name\":\"user.name\"},\"source\":\"syscalls\",\"tags\":[\"process\"],\"hostname\":\"host0.local\"}",
+    "severity": "Medium",
+    "severity_id": 3,
+    "state": "New",
+    "state_id": 1,
+    "status": "Warning",
+    "time": 1672758699558,
+    "type_name": "Security Finding: Generate",
+    "type_uid": 200101
+}


### PR DESCRIPTION
# Event Dossier: Falco
### Falco Alert
- **Description**: Translates a Falco alert to OCSF. 
- **Event References**:
  - https://falco.org/docs/alerts/channels/#json-output

 ### OCSF Version: 0.33.0
 - `activity_id`: `1` (`Generate`)
 - `category_uid`: `2` `(Findings)`
 - `class_uid`: `2001` `(Security Finding)`
 - `metadata.product.name`: `Falco`
 - `metadata.product.vendor_name`: `Falcosecurity`

 ### Mapping:
 - This does not reflect any transformations or evaluations of the data. Some data evaluation and transformation will be necessary for a correct representation in OCSF that matches all requirements.

| OCSF                   | Raw        |
| ---------------------- | ---------- |
| `finding.created_time` | `time`     |
| `finding.desc`         | `output`   |
| `finding.title`        | `rule`     |
| `finding.types`        | `source`   |
| `finding.uid`          | `uuid`     |
| `metadata.labels`      | `tags`     |
| `status`               | `priority` |