### PR TITLE
JSON bundling

### DIFF
--- a/encodings/README.md
+++ b/encodings/README.md
@@ -27,6 +27,10 @@ target.  This will not only help guide choices in the encoding mapping
 process, but also inform others as to when a particular encoding might
 be useful to adopt.
 
+One use case to be sure to cover is _bundling_; primarily a transport
+encoding, bundling is the mechanism by which multiple OCSF events are
+encoded into a single message at the underlying transport layer.
+
 ### Primitive Data Types
 
 Map the OCSF primitive data types to those available in the encoding.

--- a/encodings/json/README.md
+++ b/encodings/json/README.md
@@ -57,15 +57,13 @@ The frame should itself be a JSON object, and contain some properties:
 | Property        | Requirement | Notes                                                       |
 | --------------- | ----------- | ----------------------------------------------------------- |
 | `bundle_events` | required    | These are the actual events and the whole point of bundling |
-| `bundle_index`  | recommended | Summary information about the included events               |
 | `start_time`    | optional    | The earliest timestamp_t of any bundled events              |
 | `end_time`      | optional    | The latest timestamp_t of any bundled events                |
 | `start_time_dt` | optional    | The earliest datetime_t of any bundled events               |
 | `end_time_dt`   | optional    | The latest datetime_t of any bundled events                 |
 
-The `bundle_events` and `bundle_index` are both JSON objects with keys
-that are the unique event ids.  This structure highlights the intended
-semantics that:
+The `bundle_events` is a JSON objects with keys that are the unique
+event ids.  This structure highlights the intended semantics that:
 
 1. Each contained event both _has_ an event identifier, and that it is
    unique across the set of bundled events.
@@ -78,24 +76,12 @@ into an object, map or dict makes it easy to resolve an event by it's
 id, which is how the events in the bundle should reference each other
 when that is useful.
 
-The purpose of the `bundle_index` is to make it easier to parse the
-bundle in some contexts; some languages are more efficient if the
-structure of an object being decoded is known before attempting to
-decode it (e.g., Golang has this property).  The bundle index provides
-enough information to know what type of object is present.
-
 ```
 {
+    "start_time": 1713632701123,
     "start_time_dt": "2024-04-20T17:05:01.123456Z",
+    "end_time": 1713634257679,
     "end_time_dt": "2024-04-20T17:30:57.678912304Z",
-    "bundle_index": {
-        "88adeca9-c15c-4d7a-837a-1615c26c4f82": {
-            "class_uid": 5001
-        },
-        "7c2a9eeb-706b-4cc4-be7c-0807b6fb8867": {
-            "class_uid": 2002
-        }
-     },
     "bundle_events": {
         "88adeca9-c15c-4d7a-837a-1615c26c4f82": {
             "class_uid": 5001,

--- a/encodings/json/README.md
+++ b/encodings/json/README.md
@@ -72,7 +72,7 @@ bundling.
 Note that the bundle itself _is not_ an OCSF event.  In cases where
 bundles and events may both be present, distinguishing between bundles
 and OCSF events can be done either by inspecting the object and noting
-the presence of lack of a `class_uid`, or by making use of out-of-band
+the presence or lack of a `class_uid`, or by making use of out-of-band
 metadata.
 
 The rationale for using an array is that it is a simple JSON data type


### PR DESCRIPTION
This PR adds a discussion of "event bundling", that is, putting multiple events into a single object.

In addition to calling out the use case for encodings generally, this PR also adds a recommended encoding for bundling in JSON.