### PR TITLE
improves documentation around JSON bundling

### DIFF
--- a/encodings/json/README.md
+++ b/encodings/json/README.md
@@ -58,7 +58,7 @@ The frame should itself be a JSON object, and contain some properties:
 
 | Property        | Data Type      | Requirement | Notes                                                       |
 | --------------- | -------------- | ----------- | ----------------------------------------------------------- |
-| `events`        | array of event | required    | These are the actual events and the whole point of bundling |
+| `events`        | array of OCSF events | required    | These are the actual events and the whole point of bundling |
 | `start_time`    | `timestamp_t`  | optional    | The earliest `time` of any bundled events                   |
 | `end_time`      | `timestamp_t`  | optional    | The latest `time` of any bundled events                     |
 | `start_time_dt` | `datetime_t`   | optional    | The earliest `time_dt` of any bundled events                |

--- a/encodings/json/README.md
+++ b/encodings/json/README.md
@@ -56,14 +56,14 @@ supports easier future extensibility.
 
 The frame should itself be a JSON object, and contain some properties:
 
-| Property        | Requirement | Notes                                                       |
-| --------------- | ----------- | ----------------------------------------------------------- |
-| `events`        | required    | These are the actual events and the whole point of bundling |
-| `start_time`    | optional    | The earliest timestamp_t of any bundled events              |
-| `end_time`      | optional    | The latest timestamp_t of any bundled events                |
-| `start_time_dt` | optional    | The earliest datetime_t of any bundled events               |
-| `end_time_dt`   | optional    | The latest datetime_t of any bundled events                 |
-| `count`         | optional    | The number of bundled events                                |
+| Property        | Data Type      | Requirement | Notes                                                       |
+| --------------- | -------------- | ----------- | ----------------------------------------------------------- |
+| `events`        | array of event | required    | These are the actual events and the whole point of bundling |
+| `start_time`    | `timestamp_t`  | optional    | The earliest `time` of any bundled events                   |
+| `end_time`      | `timestamp_t`  | optional    | The latest `time` of any bundled events                     |
+| `start_time_dt` | `datetime_t`   | optional    | The earliest `time_dt` of any bundled events                |
+| `end_time_dt`   | `datetime_t`   | optional    | The latest `time_dt` of any bundled events                  |
+| `count`         | `integer_t`    | optional    | The number of bundled events                                |
 
 The `events` property is a just a JSON array of JSON-encoded OCSF
 events.  It is the only required field, and is the whole point of
@@ -78,7 +78,8 @@ metadata.
 The rationale for using an array is that it is a simple JSON data type
 to model a set of objects.  Despite the use of an array, it should be
 noted that there is no intended ordering semantics of the events in
-the bundle.
+the bundle.  In particular, it is not required that the bundled events
+be in temporal or any logical dependency order.
 
 Some of the principal use cases considered include:
 
@@ -96,16 +97,21 @@ Here is a sketch of an example bundle:
     "start_time_dt": "2024-04-20T17:05:01.123456Z",
     "end_time": 1713634257679,
     "end_time_dt": "2024-04-20T17:30:57.678912304Z",
+    "count": 2,
     "events": [
         {
             "class_uid": 5001,
             "type_uid": 500102,
-            ... details about the discovery event ...
+            "time": 1713634257679,
+            "time_dt": "2024-04-20T17:30:57.678912304Z",
+            ... details about the inventory_info event ...
         },
         {
             "class_uid": 2002,
             "type_uid": 200201,
-            ... details about the vuln finding event ...
+            "time": 1713632701123,
+            "time_dt": "2024-04-20T17:05:01.123456Z",
+            ... details about the vulnerability_finding event ...
         }
     ]
 }


### PR DESCRIPTION
Per suggestion from @rmouritzen-splunk 

- adds data types for fields in a bundle
- adds `count` to example bundle
- clarifies that order in array is not temporal or following any logical dependency order and expands timestamps in example