### PR TITLE
Fix field name in Zeek DNS mapping

### DIFF
--- a/mappings/markdown/Zeek/dns_log/samples/dns_log.ocsf
+++ b/mappings/markdown/Zeek/dns_log/samples/dns_log.ocsf
@@ -3,7 +3,7 @@
   "activity_name": "Query",
   "answers": [
     {
-      "flags": [ 3, 4 ],
+      "flags_ids": [3, 4],
       "rdata": "31.3.245.133",
       "ttl": 3600
     }


### PR DESCRIPTION
This PR fixes an issue with the field name in the Zeek DNS mapping.
